### PR TITLE
procstats: Remove the eq method from CPUTime

### DIFF
--- a/proc_read_linux_test.go
+++ b/proc_read_linux_test.go
@@ -76,7 +76,7 @@ func TestReadCPUUsage(t *testing.T) {
 			if err != nil {
 				t.Fatalf("want: %v, got: %v", c.Err, err)
 			}
-			if want, got := c.Want, ct; !want.eq(&got) {
+			if want, got := c.Want, ct; want != got {
 				t.Fatalf("want: %v, got: %v", want, got)
 			}
 		})
@@ -91,7 +91,7 @@ func TestReadCPUUsage(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		if ct.eq(&CPUTime{}) {
+		if ct == (CPUTime{}) {
 			t.Errorf("want: <non-zero>, got: %+v", ct)
 		}
 	})

--- a/proc_stats_linux.go
+++ b/proc_stats_linux.go
@@ -31,7 +31,7 @@ func init() {
 		t := time.NewTicker(time.Second)
 		defer t.Stop()
 		var ct *CPUTime
-		for i := 0; i < 30 || ct.eq(&CPUTime{}); i++ {
+		for i := 0; i < 30 || (*ct == CPUTime{}); i++ {
 			<-t.C
 			b, err := ioutil.ReadFile(self)
 			if err != nil {

--- a/pstats.go
+++ b/pstats.go
@@ -44,12 +44,6 @@ func ProcessCPUTime(pid int) (CPUTime, error) {
 	return readProcessCPUTime(pid)
 }
 
-// Eq reports if the two CPUTimes are equal.
-func (c *CPUTime) eq(b *CPUTime) bool {
-	return c.Utime == b.Utime &&
-		c.Stime == b.Stime
-}
-
 // MaxRSS returns the maximum RSS (High Water Mark) of the process with PID
 // pid.
 func MaxRSS(pid int) (int64, error) {


### PR DESCRIPTION
The `eq` method was unexported and as such was only used in tests. Given
that we exposed other operator-like methods it was a bit of an anomaly
in being unexported.

To make it doubly weird, the default-generated `==` operator does
exactly what one would expect for the concrete type, so there's *no*
need for an `eq` method. Just rip it out and udpate the 3 tests that
used it.

Fun fact: some of the call-sites required adding parenthesis because otherwise the Go parser gets upset when it sees a pair of braces and then sees the open-brace for the body of the if statement.